### PR TITLE
Allow a subclass of Executable to provide its own implementation of deleting the executable.

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
@@ -68,14 +68,22 @@ public abstract class Executable<T extends ExecutableProcessConfig,P extends ISt
 				s.stop();
 			}
 			stopables=Lists.newArrayList();
-			
-			if (executable.exists() && !Files.forceDelete(executable))
-				logger.warning("Could not delete executable NOW: " + executable);
-			stopped = true;
+
+            deleteExecutable();
+            stopped = true;
 		}
 	}
 
-	/**
+    /**
+     * Delete the executable at stop time; available here for
+     * subclassing.
+     */
+    protected void deleteExecutable() {
+        if (executable.exists() && !Files.forceDelete(executable))
+            logger.warning("Could not delete executable NOW: " + executable);
+    }
+
+    /**
 	 *
 	 */
 	class JobKiller implements Runnable {


### PR DESCRIPTION
 Perhaps it doesn't want to delete it at all, because it wants to start and stop more than once on one unpack?
