### PR TITLE
Make Downloader implement IDownloader so that we can have a second implentation

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/store/ArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/ArtifactStore.java
@@ -53,17 +53,19 @@ public class ArtifactStore implements IArtifactStore {
 	private IDownloadConfig _downloadConfig;
 	private IDirectory _tempDirFactory;
 	private ITempNaming _executableNaming;
+	private IDownloader _downloader;
 	
-	public ArtifactStore(IDownloadConfig downloadConfig,IDirectory tempDirFactory,ITempNaming executableNaming) {
+	public ArtifactStore(IDownloadConfig downloadConfig,IDirectory tempDirFactory,ITempNaming executableNaming,IDownloader downloader) {
 		_downloadConfig=downloadConfig;
 		_tempDirFactory = tempDirFactory;
 		_executableNaming = executableNaming;
+		_downloader = downloader;
 	}
 	
 	@Override
 	public boolean checkDistribution(Distribution distribution) throws IOException {
 		if (!LocalArtifactStore.checkArtifact(_downloadConfig, distribution)) {
-			return LocalArtifactStore.store(_downloadConfig, distribution, Downloader.download(_downloadConfig, distribution));
+			return LocalArtifactStore.store(_downloadConfig, distribution, _downloader.download(_downloadConfig, distribution));
 		}
 		return true;
 	}

--- a/src/main/java/de/flapdoodle/embed/process/store/ArtifactStoreBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/ArtifactStoreBuilder.java
@@ -40,6 +40,7 @@ public class ArtifactStoreBuilder extends AbstractBuilder<IArtifactStore> {
 	private static final TypedProperty<IDownloadConfig> DOWNLOAD_CONFIG = TypedProperty.with("DownloadConfig",IDownloadConfig.class);
 	private static final TypedProperty<Boolean> USE_CACHE = TypedProperty.with("UseCache",Boolean.class);
 	private static final TypedProperty<ILibraryStore> LIBRARIES = TypedProperty.with("Libraries", ILibraryStore.class);
+	private static final TypedProperty<IDownloader> DOWNLOADER = TypedProperty.with("Downloader",IDownloader.class);
 	
 	public ArtifactStoreBuilder download(AbstractBuilder<IDownloadConfig> downloadConfigBuilder) {
 		return download(downloadConfigBuilder.build());
@@ -98,14 +99,23 @@ public class ArtifactStoreBuilder extends AbstractBuilder<IArtifactStore> {
 		return property(LIBRARIES);
 	}
 
-	
+	public ArtifactStoreBuilder downloader(IDownloader downloader) {
+		set(DOWNLOADER, downloader);
+		return this;
+	}
+
+	protected IProperty<IDownloader> downloader() {
+		return property(DOWNLOADER);
+	}
+
+
 	@Override
 	public IArtifactStore build() {
 		boolean useCache = get(USE_CACHE, true);
 		
 		logger.fine("Build ArtifactStore(useCache:"+useCache+")");
 		
-		IArtifactStore artifactStore = new ArtifactStore(get(DOWNLOAD_CONFIG),get(TEMP_DIR_FACTORY), get(EXECUTABLE_NAMING));
+		IArtifactStore artifactStore = new ArtifactStore(get(DOWNLOAD_CONFIG),get(TEMP_DIR_FACTORY), get(EXECUTABLE_NAMING), get(DOWNLOADER));
 		if (useCache) {
 			artifactStore=new CachingArtifactStore(artifactStore);
 		}

--- a/src/main/java/de/flapdoodle/embed/process/store/Downloader.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/Downloader.java
@@ -42,21 +42,17 @@ import de.flapdoodle.embed.process.io.progress.IProgressListener;
 /**
  * Class for downloading runtime
  */
-public class Downloader {
+public class Downloader implements IDownloader {
 
 	static final int DEFAULT_CONTENT_LENGTH = 20 * 1024 * 1024;
 	static final int BUFFER_LENGTH = 1024 * 8 * 8;
 	static final int READ_COUNT_MULTIPLIER = 100;
 
-	private Downloader() {
-
-	}
-
-	public static String getDownloadUrl(IDownloadConfig runtime, Distribution distribution) {
+	public String getDownloadUrl(IDownloadConfig runtime, Distribution distribution) {
 		return runtime.getDownloadPath().getPath(distribution) + runtime.getPackageResolver().getPath(distribution);
 	}
 
-	public static File download(IDownloadConfig downloadConfig, Distribution distribution) throws IOException {
+	public File download(IDownloadConfig downloadConfig, Distribution distribution) throws IOException {
 
 		String progressLabel = "Download " + distribution;
 		IProgressListener progress = downloadConfig.getProgressListener();
@@ -106,7 +102,7 @@ public class Downloader {
 		return ret;
 	}
 
-	private static InputStreamAndLength downloadInputStream(IDownloadConfig downloadConfig, Distribution distribution)
+	private InputStreamAndLength downloadInputStream(IDownloadConfig downloadConfig, Distribution distribution)
 			throws MalformedURLException, IOException {
 		URL url = new URL(getDownloadUrl(downloadConfig, distribution));
 		
@@ -134,7 +130,7 @@ public class Downloader {
 		}
 	}
 
-	private static String downloadSpeed(long downloadStartedAt,long downloadSize) {
+	private String downloadSpeed(long downloadStartedAt,long downloadSize) {
 		long timeUsed=(System.currentTimeMillis()-downloadStartedAt)/1000;
 		if (timeUsed==0) {
 			timeUsed=1;

--- a/src/main/java/de/flapdoodle/embed/process/store/IDownloader.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/IDownloader.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	Kevin D. Keck (kdkeck@github), Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.store;
+
+import java.io.File;
+import java.io.IOException;
+
+import de.flapdoodle.embed.process.config.store.IDownloadConfig;
+import de.flapdoodle.embed.process.distribution.Distribution;
+
+public interface IDownloader {
+
+    String getDownloadUrl(IDownloadConfig runtime, Distribution distribution);
+
+    File download(IDownloadConfig runtime, Distribution distribution) throws IOException;
+}

--- a/src/test/java/de/flapdoodle/embed/process/example/GenericRuntimeConfigBuilder.java
+++ b/src/test/java/de/flapdoodle/embed/process/example/GenericRuntimeConfigBuilder.java
@@ -46,6 +46,7 @@ import de.flapdoodle.embed.process.io.directories.UserHome;
 import de.flapdoodle.embed.process.io.progress.StandardConsoleProgressListener;
 import de.flapdoodle.embed.process.runtime.ICommandLinePostProcessor;
 import de.flapdoodle.embed.process.store.ArtifactStoreBuilder;
+import de.flapdoodle.embed.process.store.Downloader;
 
 
 public class GenericRuntimeConfigBuilder extends AbstractBuilder<IRuntimeConfig> {
@@ -105,6 +106,7 @@ public class GenericRuntimeConfigBuilder extends AbstractBuilder<IRuntimeConfig>
 					.fileNaming(new UUIDTempNaming())
 					.progressListener(new StandardConsoleProgressListener())
 					.userAgent("Mozilla/5.0 (compatible; embedded "+name+"; +https://github.com/flapdoodle-oss/de.flapdoodle.embed.process)"))
+				.downloader(new Downloader())
 				.tempDir(new PropertyOrPlatformTempDir())
 				.executableNaming(new UUIDTempNaming()))
 			.processOutput(ProcessOutput.getDefaultInstance(name))


### PR DESCRIPTION
I'd like to use de.flapdoodle.embed.process to create an embedded version of TokuMX (a popular MongoDB fork). Because of the way TokuMX is hosted, I need to use a custom downloader.
