### PR TITLE
Replace java.util.logging with Slf4j facade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ dependencies {
     testCompile 'org.mongodb:mongo-java-driver:2.6.3'
     testCompile 'org.mockito:mockito-core:1.9.0'
     testCompile 'org.mortbay.jetty:jetty:6.1.25'
+    testCompile 'org.slf4j:slf4j-simple:1.7.10'
     compile 'commons-io:commons-io:2.1'
     compile 'org.apache.commons:commons-compress:1.3'
+    compile 'org.slf4j:slf4j-api:1.7.10'
 }
 
 task wrapper(type: Wrapper) {

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,8 @@
                         <include>**/test/**</include>
                     </includes>
                     <excludes>
-                        <include>**/*.txt</include>
+                        <exclude>**/*.txt</exclude>
+                        <exclude>**/*.properties</exclude>
                     </excludes>
                     <!--
                              <excludes> <exclude>target/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,8 @@
 			org.apache.commons.compress.compressors.bzip2,
 			org.apache.commons.compress.compressors.gzip,
 			org.apache.commons.lang3,
-			org.apache.commons.io
+			org.apache.commons.io,
+			org.slf4j
 		</osgi.import>
 	</properties>
 	
@@ -301,6 +302,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
@@ -310,6 +317,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/de/flapdoodle/embed/process/config/io/ProcessOutput.java
+++ b/src/main/java/de/flapdoodle/embed/process/config/io/ProcessOutput.java
@@ -24,10 +24,10 @@
 package de.flapdoodle.embed.process.config.io;
 
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import de.flapdoodle.embed.process.io.IStreamProcessor;
 import de.flapdoodle.embed.process.io.Processors;
+import de.flapdoodle.embed.process.io.Slf4jLevel;
 
 
 public class ProcessOutput {
@@ -64,10 +64,15 @@ public class ProcessOutput {
 		return new ProcessOutput(Processors.silent(),Processors.silent(),Processors.silent());
 	}
 
-	public static ProcessOutput getInstance(String label, Logger logger) {
+	public static ProcessOutput getInstance(String label, java.util.logging.Logger logger) {
 		return new ProcessOutput(Processors.named("["+label+" output]", Processors.logTo(logger, Level.INFO)),
 				Processors.named("["+label+" error]", Processors.logTo(logger, Level.SEVERE)),
 				Processors.logTo(logger, Level.FINE));
 	}
 
+	public static ProcessOutput getInstance(String label, org.slf4j.Logger logger) {
+		return new ProcessOutput(Processors.named("["+label+" output]", Processors.logTo(logger, Slf4jLevel.INFO)),
+				Processors.named("["+label+" error]", Processors.logTo(logger, Slf4jLevel.ERROR)),
+				Processors.logTo(logger, Slf4jLevel.DEBUG));
+	}
 }

--- a/src/main/java/de/flapdoodle/embed/process/extract/AbstractExtractor.java
+++ b/src/main/java/de/flapdoodle/embed/process/extract/AbstractExtractor.java
@@ -32,12 +32,12 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractExtractor implements IExtractor {
 	
-	private static Logger _logger=Logger.getLogger(AbstractExtractor.class.getName());
+	private static Logger _logger=LoggerFactory.getLogger(AbstractExtractor.class);
 	
 	protected abstract ArchiveWrapper archiveStream(File source) throws FileNotFoundException, IOException;
 
@@ -45,7 +45,10 @@ public abstract class AbstractExtractor implements IExtractor {
 		try {
 			return archiveStream(source);
 		} catch (IOException iox) {
-			_logger.log(Level.WARNING,"\n--------------------------\nIf you get this exception more than once, you should check if the file is corrupt.\nIf you remove the file ("+source.getAbsolutePath()+"), it will be downloaded again.\n--------------------------",iox);
+			_logger.warn("\n--------------------------\n"
+                    + "If you get this exception more than once, you should check if the file is corrupt.\n"
+                    + "If you remove the file ({}), it will be downloaded again.\n"
+                    + "--------------------------", source.getAbsolutePath(), iox);
 			throw new IOException("File "+source.getAbsolutePath(),iox);
 		}
 	}

--- a/src/main/java/de/flapdoodle/embed/process/io/Processors.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/Processors.java
@@ -25,7 +25,6 @@ package de.flapdoodle.embed.process.io;
 
 import java.io.Reader;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
@@ -52,10 +51,14 @@ public class Processors {
 		return named(name, console());
 	}
 
-	public static IStreamProcessor logTo(Logger logger, Level level) {
+	public static IStreamProcessor logTo(java.util.logging.Logger logger, Level level) {
 		return new LoggingOutputStreamProcessor(logger, level);
 	}
-	
+
+	public static IStreamProcessor logTo(org.slf4j.Logger logger, Slf4jLevel level) {
+		return new Slf4jStreamProcessor(logger, level);
+	}
+
 	public static ReaderProcessor connect(Reader reader, IStreamProcessor processor) {
 		return new ReaderProcessor(reader, processor);
 	}

--- a/src/main/java/de/flapdoodle/embed/process/io/Slf4jLevel.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/Slf4jLevel.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.io;
+
+import org.slf4j.Logger;
+
+public enum Slf4jLevel {
+
+    TRACE {
+        public void log(Logger logger, String message, Object... arguments) {
+            logger.trace(message, arguments);
+        }
+    },
+    DEBUG {
+        public void log(Logger logger, String message, Object... arguments) {
+            logger.debug(message, arguments);
+        }
+    },
+    INFO {
+        public void log(Logger logger, String message, Object... arguments) {
+            logger.info(message, arguments);
+        }
+    },
+    WARN {
+        public void log(Logger logger, String message, Object... arguments) {
+            logger.warn(message, arguments);
+        }
+    },
+    ERROR {
+        public void log(Logger logger, String message, Object... arguments) {
+            logger.error(message, arguments);
+        }
+    };
+
+    public abstract void log(Logger logger, String message, Object... arguments);
+}

--- a/src/main/java/de/flapdoodle/embed/process/io/Slf4jStreamProcessor.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/Slf4jStreamProcessor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.io;
+
+import org.slf4j.Logger;
+
+public class Slf4jStreamProcessor implements IStreamProcessor {
+
+    private final Logger logger;
+    private final Slf4jLevel level;
+
+
+    public Slf4jStreamProcessor(Logger logger, Slf4jLevel level) {
+        this.logger = logger;
+        this.level = level;
+    }
+
+    public void process(String line) {
+        level.log(logger, stripLineEndings(line));
+    }
+
+    public void onProcessed() {
+    }
+
+
+    protected String stripLineEndings(String line) {
+        // we still need to remove line endings that are passed on by StreamToLineProcessor...
+        return line.replaceAll("[\n\r]+", "");
+    }
+}

--- a/src/main/java/de/flapdoodle/embed/process/io/file/FileCleaner.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/file/FileCleaner.java
@@ -27,14 +27,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.commons.io.FileUtils;
 
 public class FileCleaner {
 
-	private static Logger logger = Logger.getLogger(FileCleaner.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(FileCleaner.class);
 
 	static final int MAX_FILES_TO_CLEAN = 10000;
 	static final int MAX_RETRIES = 100;
@@ -111,7 +111,7 @@ public class FileCleaner {
 					} catch (IOException iox) {
 						int newCounter = fileToClean.get(f) + 1;
 						if (newCounter > MAX_RETRIES) {
-							logger.log(Level.SEVERE, "Could not delete " + f + " after " + newCounter + " retries, leave it unchanged");
+							logger.error("Could not delete {} after {} retries, leave it unchanged", f, newCounter);
 							fileToClean.remove(f);
 						} else {
 							fileToClean.put(f, newCounter);
@@ -126,7 +126,7 @@ public class FileCleaner {
 				synchronized (fileToClean) {
 					if (fileToClean.size() < MAX_FILES_TO_CLEAN) {
 						Integer oldValue = fileToClean.put(fileOrDir, 0);
-						if (oldValue!=null) logger.log(Level.SEVERE, "forceDelete " + fileOrDir + ", but allready in list with " + oldValue + " tries.");
+						if (oldValue!=null) logger.error("forceDelete {}, but allready in list with {} tries.", fileOrDir, oldValue);
 						fileToClean.notify();
 					} else {
 						throw new RuntimeException("filesToClean exceeded " + MAX_FILES_TO_CLEAN

--- a/src/main/java/de/flapdoodle/embed/process/io/file/Files.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/file/Files.java
@@ -35,14 +35,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.util.UUID;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class Files {
 
-	private static Logger logger = Logger.getLogger(Files.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(Files.class);
 	public static final int BYTE_BUFFER_LENGTH = 1024 * 16;
 
 	private Files() {
@@ -113,12 +114,11 @@ public class Files {
 		try {
 			if ((fileOrDir != null) && (fileOrDir.exists())) {
 				FileUtils.forceDelete(fileOrDir);
-				logger.fine("Could delete " + fileOrDir);
+				logger.debug("Could delete {}", fileOrDir);
 				ret = true;
 			}
 		} catch (IOException e) {
-			logger.warning("Could not delete " + fileOrDir
-					+ ". Will try to delete it again when program exits.");
+			logger.warn("Could not delete {}. Will try to delete it again when program exits.", fileOrDir);
 			FileCleaner.forceDeleteOnExit(fileOrDir);
 			ret = true;
 		}

--- a/src/main/java/de/flapdoodle/embed/process/io/progress/Slf4jProgressListener.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/progress/Slf4jProgressListener.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.io.progress;
+
+import org.slf4j.Logger;
+
+public class Slf4jProgressListener implements IProgressListener {
+
+    private final Logger logger;
+    private int lastPercent = -1;
+
+
+    public Slf4jProgressListener(Logger logger) {
+        this.logger = logger;
+    }
+
+
+    @Override
+    public void progress(String label, int percent) {
+        if (percent != lastPercent && percent % 10 == 0) {
+            logger.info("{} : {} %", label, percent);
+        }
+        lastPercent = percent;
+    }
+
+    @Override
+    public void done(String label) {
+        logger.info("{} : finished", label);
+    }
+
+    @Override
+    public void start(String label) {
+        logger.info("{} : starting...", label);
+    }
+
+    @Override
+    public void info(String label, String message) {
+        logger.info("{} : {}", label, message);
+    }
+}

--- a/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +46,7 @@ import de.flapdoodle.embed.process.io.file.Files;
 public abstract class AbstractProcess<T extends IExecutableProcessConfig, E extends Executable<T, P>, P extends IStopable>
 		implements IStopable {
 
-	private static Logger logger = Logger.getLogger(AbstractProcess.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(AbstractProcess.class);
 
 	public static final int TIMEOUT = 20000;
 
@@ -112,8 +112,8 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 			onAfterProcessStart(process, runtimeConfig);
 
 		} catch (IOException iox) {
-			logger.log(Level.SEVERE, "failed to call "+nextCall,iox);
-			logger.logp(Level.INFO, getClass().getSimpleName(), "ctor", config.toString());
+			logger.error("failed to call {}", nextCall, iox);
+			logger.info("construct {}", config.toString());
 			stop();
 			throw iox;
 		}
@@ -168,7 +168,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 			onAfterProcessStop(this.config, this.runtimeConfig);
 			cleanupInternal();
 			if (!Files.forceDelete(pidFile)) {
-				logger.warning("Could not delete pid file: " + pidFile);
+				logger.warn("Could not delete pid file: {}", pidFile);
 			}
 		}
 	}
@@ -250,7 +250,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 			} catch (InterruptedException e1) {
 				// ignore
 			}
-			logger.warning("Didn't find pid file in try " + tries + ", waiting 100ms...");
+			logger.warn("Didn't find pid file in try {}, waiting 100ms...", tries);
 			tries++;
 		}
 		// don't check file to be there. want to throw IOException if

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
@@ -26,8 +26,8 @@ package de.flapdoodle.embed.process.runtime;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.config.IExecutableProcessConfig;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -36,7 +36,7 @@ import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 
 public abstract class Executable<T extends IExecutableProcessConfig, P extends IStopable> implements IStopable {
 
-	private static Logger logger = Logger.getLogger(Executable.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(Executable.class);
 
 	private final T config;
 	private final IRuntimeConfig runtimeConfig;
@@ -99,7 +99,7 @@ public abstract class Executable<T extends IExecutableProcessConfig, P extends I
 		if (stopped) throw new RuntimeException("Already stopped");
 
 		P start = start(distribution, config, runtimeConfig);
-		logger.logp(Level.INFO, getClass().getSimpleName(),"start" ,config.toString());
+		logger.info("start {}", config);
 		addStopable(start);
 		return start;
 	}

--- a/src/main/java/de/flapdoodle/embed/process/runtime/NUMA.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/NUMA.java
@@ -27,7 +27,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.collections.Collections;
 import de.flapdoodle.embed.process.config.ISupportConfig;
@@ -39,7 +40,7 @@ import de.flapdoodle.embed.process.io.Readers;
  */
 public class NUMA {
 
-	private static Logger logger = Logger.getLogger(NUMA.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(NUMA.class);
 
 	public static synchronized boolean isNUMA(ISupportConfig support, Platform platform) {
 		Boolean ret = NUMA_STATUS_MAP.get(platform);
@@ -63,7 +64,7 @@ public class NUMA {
 				process.stop();
 				boolean isNUMA = !content.isEmpty();
 				if (isNUMA) {
-					logger.warning("-----------------------------------------------\n"
+					logger.warn("-----------------------------------------------\n"
 							+ "NUMA support is still alpha. If you have any Problems with it, please contact us.\n"
 							+ "-----------------------------------------------");
 				}

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Network.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Network.java
@@ -27,15 +27,15 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class Network {
 
-	private static Logger logger = Logger.getLogger(Network.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(Network.class);
 	
 	private static final String NO_LOCALHOST_ERROR_MESSAGE = "We could not detect if localhost is IPv4 or IPv6. " +
 			"Sometimes there is no entry for localhost. " +
@@ -55,7 +55,7 @@ public class Network {
 			}
 			return false;
 		} catch (UnknownHostException ux) {
-			logger.log(Level.SEVERE, NO_LOCALHOST_ERROR_MESSAGE, ux);
+			logger.error(NO_LOCALHOST_ERROR_MESSAGE, ux);
 			throw ux;
 		}
 	}
@@ -65,7 +65,7 @@ public class Network {
 		if (!ret.isLoopbackAddress()) {
 			ret = InetAddress.getByName("localhost");
 			if (!ret.isLoopbackAddress()) {
-				logger.severe("" + ret.getHostAddress() + " is not a loopback address");
+				logger.error("{} is not a loopback address", ret.getHostAddress());
 			}
 		}
 		return ret;

--- a/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
@@ -34,8 +34,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.config.ISupportConfig;
 import de.flapdoodle.embed.process.config.process.ProcessConfig;
@@ -43,7 +43,7 @@ import de.flapdoodle.embed.process.io.Processors;
 
 public class ProcessControl {
 
-	private static Logger logger = Logger.getLogger(ProcessControl.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ProcessControl.class);
 	private static final int SLEEPT_TIMEOUT = 10;
 
 	private Process process;
@@ -85,7 +85,7 @@ public class ProcessControl {
 				process.getOutputStream().close();
 
 			} catch (IOException e) {
-				logger.severe(e.getMessage());
+				logger.error(e.getMessage());
 			}
 			reader = null;
 		}
@@ -227,12 +227,12 @@ public class ProcessControl {
 			Processors.connect(process.getReader(), processConfig.getOutput());
 			Thread.sleep(SLEEPT_TIMEOUT);
 			ret = process.stop() == 0;
-			logger.info("execSuccess: " + ret + " " + commandLine);
+			logger.info("execSuccess: {} {}", ret, commandLine);
 			return ret;
 		} catch (IOException e) {
-			logger.log(Level.SEVERE, "" + commandLine, e);
+			logger.error("" + commandLine, e);
 		} catch (InterruptedException e) {
-			logger.log(Level.SEVERE, "" + commandLine, e);
+			logger.error("" + commandLine, e);
 		}
 		return false;
 	}

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Starter.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Starter.java
@@ -24,8 +24,8 @@
 package de.flapdoodle.embed.process.runtime;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.config.IExecutableProcessConfig;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -37,7 +37,7 @@ import de.flapdoodle.embed.process.store.IArtifactStore;
 
 public abstract class Starter<CONFIG extends IExecutableProcessConfig,EXECUTABLE extends Executable<CONFIG, PROCESS>,PROCESS extends IStopable> {
 	
-	private static Logger logger = Logger.getLogger(Starter.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(Starter.class);
 	
 	private final IRuntimeConfig runtime;
 	
@@ -64,7 +64,7 @@ public abstract class Starter<CONFIG extends IExecutableProcessConfig,EXECUTABLE
 			if (messageOnException==null) {
 				messageOnException="prepare executable";
 			}
-			logger.log(Level.SEVERE, messageOnException, iox);
+			logger.error(messageOnException, iox);
 			throw new DistributionException(distribution,iox);
 		}
 	}

--- a/src/main/java/de/flapdoodle/embed/process/store/ArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/ArtifactStore.java
@@ -26,7 +26,8 @@ package de.flapdoodle.embed.process.store;
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.config.store.FileType;
 import de.flapdoodle.embed.process.config.store.IDownloadConfig;
@@ -42,7 +43,7 @@ import de.flapdoodle.embed.process.io.file.Files;
 
 
 public class ArtifactStore implements IArtifactStore {
-	private static Logger logger = Logger.getLogger(ArtifactStore.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ArtifactStore.class);
 
 	private IDownloadConfig _downloadConfig;
 	private IDirectory _tempDirFactory;
@@ -80,17 +81,17 @@ public class ArtifactStore implements IArtifactStore {
 		for (FileType type : EnumSet.complementOf(EnumSet.of(FileType.Executable))) {
 			for (File file : all.files(type)) {
 				if (file.exists() && !Files.forceDelete(file))
-					logger.warning("Could not delete "+type+" NOW: " + file);				
+					logger.warn("Could not delete {} NOW: {}", type, file);
 			}
 		}
 		File exe=all.executable();
 		if (exe.exists() && !Files.forceDelete(exe)) {
-			logger.warning("Could not delete executable NOW: " + exe);
+			logger.warn("Could not delete executable NOW: {}", exe);
 		}
 		
 		if (all.generatedBaseDir()!=null) {
 			if (!Files.forceDelete(all.generatedBaseDir())) {
-				logger.warning("Could not delete generatedBaseDir: " + all.generatedBaseDir());
+				logger.warn("Could not delete generatedBaseDir: {}", all.generatedBaseDir());
 			}
 		}
 	}

--- a/src/main/java/de/flapdoodle/embed/process/store/ArtifactStoreBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/ArtifactStoreBuilder.java
@@ -23,7 +23,8 @@
  */
 package de.flapdoodle.embed.process.store;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.builder.AbstractBuilder;
 import de.flapdoodle.embed.process.builder.IProperty;
@@ -34,7 +35,7 @@ import de.flapdoodle.embed.process.extract.ITempNaming;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
 
 public class ArtifactStoreBuilder extends AbstractBuilder<IArtifactStore> {
-	private static Logger logger = Logger.getLogger(ArtifactStoreBuilder.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ArtifactStoreBuilder.class);
 
 	private static final TypedProperty<ITempNaming> EXECUTABLE_NAMING = TypedProperty.with("ExecutableNaming",ITempNaming.class);
 	private static final TypedProperty<IDirectory> TEMP_DIR_FACTORY = TypedProperty.with("TempDir",IDirectory.class);
@@ -114,7 +115,7 @@ public class ArtifactStoreBuilder extends AbstractBuilder<IArtifactStore> {
 	public IArtifactStore build() {
 		boolean useCache = get(USE_CACHE, true);
 		
-		logger.fine("Build ArtifactStore(useCache:"+useCache+")");
+		logger.debug("Build ArtifactStore(useCache: {})", useCache);
 		
 		IArtifactStore artifactStore = new ArtifactStore(get(DOWNLOAD_CONFIG),get(TEMP_DIR_FACTORY), get(EXECUTABLE_NAMING), get(DOWNLOADER));
 		if (useCache) {

--- a/src/main/java/de/flapdoodle/embed/process/store/CachingArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/CachingArtifactStore.java
@@ -29,7 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
@@ -37,7 +38,7 @@ import de.flapdoodle.embed.process.runtime.ProcessControl;
 
 public class CachingArtifactStore implements IArtifactStore {
 
-	private static Logger _logger = Logger.getLogger(CachingArtifactStore.class.getName());
+	private static Logger _logger = LoggerFactory.getLogger(CachingArtifactStore.class);
 
 	private final IArtifactStore _delegate;
 
@@ -66,11 +67,11 @@ public class CachingArtifactStore implements IArtifactStore {
 		synchronized (_lock) {
 			fileWithCounter = _distributionFiles.get(distribution);
 			if (fileWithCounter == null) {
-				_logger.fine("cache NOT found for "+distribution);
+				_logger.debug("cache NOT found for {}", distribution);
 				fileWithCounter=new FilesWithCounter(distribution);
 				_distributionFiles.put(distribution, fileWithCounter);
 			} else {
-				_logger.fine("cache found for "+distribution);
+				_logger.debug("cache found for {}", distribution);
 			}
 		}
 		
@@ -86,7 +87,7 @@ public class CachingArtifactStore implements IArtifactStore {
 		if (fileWithCounter!=null) {
 			fileWithCounter.free(executable);
 		} else {
-			_logger.warning("Allready removed "+executable+" for "+distribution+", emergency shutdown?");
+			_logger.warn("Allready removed {} for {}, emergency shutdown?", executable, distribution);
 		}
 	}
 
@@ -120,7 +121,7 @@ public class CachingArtifactStore implements IArtifactStore {
 
 		public synchronized void free(IExtractedFileSet executable) {
 			if (executable!=_file) throw new RuntimeException("Files does not match: "+_file+" != "+executable);
-			_logger.fine("Free "+_counter+" "+_file);
+			_logger.debug("Free {} {}", _counter, _file);
 			_counter--;
 		}
 
@@ -129,18 +130,18 @@ public class CachingArtifactStore implements IArtifactStore {
 			
 			if (_file==null) {
 				_file=_delegate.extractFileSet(_distribution);
-				_logger.fine("Not Cached "+_counter+" "+_file);
+				_logger.debug("Not Cached {} {}", _counter, _file);
 			} else {
-				_logger.fine("Cached "+_counter+" "+_file);
+				_logger.debug("Cached {} {}", _counter, _file);
 			}
 			return _file;
 		}
 		
 		public synchronized void cleanup() {
 			if (_counter<=0) {
-				if (_counter<0) _logger.warning("Counter < 0 for "+_distribution+" and "+_file);
+				if (_counter<0) _logger.warn("Counter < 0 for {} and {}", _distribution, _file);
 				if (_file!=null) {
-					_logger.fine("cleanup for "+_distribution+" and "+_file);
+					_logger.debug("cleanup for {} and {}", _distribution, _file);
 					_delegate.removeFileSet(_distribution, _file);
 					_file=null;
 				}
@@ -149,7 +150,7 @@ public class CachingArtifactStore implements IArtifactStore {
 		
 		public synchronized void forceDelete() {
 			if (_file!=null) {
-				_logger.fine("force delete for "+_distribution+" and "+_file);
+				_logger.debug("force delete for {} and {}", _distribution, _file);
 				_delegate.removeFileSet(_distribution, _file);
 				_file=null;
 				_counter=0;

--- a/src/test/java/de/flapdoodle/embed/process/io/file/TestFileCleaner.java
+++ b/src/test/java/de/flapdoodle/embed/process/io/file/TestFileCleaner.java
@@ -31,7 +31,8 @@ import java.nio.channels.FileLock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junit.framework.TestCase;
 
@@ -40,7 +41,7 @@ import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
 
 public class TestFileCleaner extends TestCase {
 
-	private static Logger logger = Logger.getLogger(TestFileCleaner.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(TestFileCleaner.class.getName());
 
 	String prefix = UUID.randomUUID().toString();
 	

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=trace


### PR DESCRIPTION
See https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/67.

I’ve modified it with API backward compatibility in mind, so it shouldn’t break existing code that depends on it.