### PR TITLE
Making PID determination work on JDK 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
 			de.flapdoodle.embed.process.store;version=${project.version}
 		</osgi.export>
 		<osgi.import>
+			javax.lang.model,
 			com.sun.jna,
 			com.sun.jna.platform.win32,
 			org.apache.commons.compress.archivers,

--- a/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.process.config.IExecutableProcessConfig;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -99,8 +99,10 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 
 			nextCall="writePidFile()";
 
-			writePidFile(pidFile, process.getPid());
-			
+			if (process.getPid() != null) {
+				writePidFile(pidFile, process.getPid());
+			}
+
 			nextCall="addShutdownHook()";
 
 			if (runtimeConfig.isDaemonProcess()) {
@@ -226,8 +228,8 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 		return false;
 	}
 
-	public int getProcessId() {
-		Integer pid = process.getPid();
+	public long getProcessId() {
+		Long pid = process.getPid();
 		return pid!=null ? pid : processId;
 	}
 
@@ -284,7 +286,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 		}
 	}
 
-	protected void writePidFile(File pidFile, int pid) throws IOException {
+	protected void writePidFile(File pidFile, long pid) throws IOException {
 		Files.write(pid + "\n", pidFile);
 	}
 }

--- a/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
@@ -58,9 +58,9 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 
 	private boolean stopped = false;
 
-	private Distribution distribution;
+	private final Distribution distribution;
 
-	private File pidFile;
+	private final File pidFile;
 
 	public AbstractProcess(Distribution distribution, T config, IRuntimeConfig runtimeConfig, E executable)
 			throws IOException {
@@ -70,7 +70,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 		this.distribution = distribution;
 		// pid file needs to be set before ProcessBuilder is called
 		this.pidFile = pidFile(this.executable.getFile().executable());
-		
+
 		ProcessOutput outputConfig = runtimeConfig.getProcessOutput();
 
 		// Refactor me - to much things done in this try/catch
@@ -80,7 +80,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 			nextCall="onBeforeProcess()";
 
 			onBeforeProcess(runtimeConfig);
-			
+
 			nextCall="newProcessBuilder()";
 
 			ProcessBuilder processBuilder = ProcessControl.newProcessBuilder(
@@ -88,7 +88,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 							getCommandLine(distribution, config, this.executable.getFile())),
 					getEnvironment(distribution, config, this.executable.getFile()), true);
 
-			
+
 			nextCall="onBeforeProcessStart()";
 
 			onBeforeProcessStart(processBuilder, config, runtimeConfig);
@@ -96,7 +96,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 			nextCall="start()";
 
 			process = ProcessControl.start(config.supportConfig(), processBuilder);
-			
+
 			nextCall="writePidFile()";
 
 			writePidFile(pidFile, process.getPid());
@@ -122,7 +122,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 	protected File pidFile(File executeableFile) {
 		return new File(executeableFile.getParentFile(),executableBaseName(executeableFile.getName())+".pid");
 	}
-	
+
 	protected File pidFile() {
 		return pidFile;
 	}
@@ -161,6 +161,7 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 		return new HashMap<String, String>();
 	}
 
+	@Override
 	public synchronized final void stop() {
 		if (!stopped) {
 			stopped = true;

--- a/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,14 +47,14 @@ public class ProcessControl {
 	private static Logger logger = LoggerFactory.getLogger(ProcessControl.class);
 	private static final int SLEEPT_TIMEOUT = 10;
 
-	private Process process;
+	private final Process process;
 
 	private InputStreamReader reader;
-	private InputStreamReader error;
+	private final InputStreamReader error;
 
-	private Integer pid;
+	private final Long pid;
 
-	private ISupportConfig runtime;
+	private final ISupportConfig runtime;
 
 	public ProcessControl(ISupportConfig runtime, Process process) {
 		this.process = process;
@@ -93,13 +94,13 @@ public class ProcessControl {
 
 	private Integer stopOrDestroyProcess() {
 		Integer returnCode=null;
-		
+
 		try {
 			returnCode=process.exitValue();
 		} catch (IllegalThreadStateException itsx) {
 		    	logger.info("stopOrDestroyProcess: "+itsx.getMessage() +" "+((itsx.getCause()!=null) ? itsx.getCause() : "") );
 			Callable<Integer> callable=new Callable<Integer>() {
-				
+
 				@Override
 				public Integer call() throws Exception {
 					return process.waitFor();
@@ -116,9 +117,9 @@ public class ProcessControl {
 			} catch (ExecutionException e) {
 			} catch (TimeoutException e) {
 			}
-			
+
 			closeIOAndDestroy();
-			
+
 			try {
 				returnCode=task.get(900, TimeUnit.MILLISECONDS);
 				stopped=true;
@@ -140,7 +141,7 @@ public class ProcessControl {
 				process.destroy();
 			}
 		}
-		
+
 		return returnCode;
 	}
 
@@ -207,7 +208,7 @@ public class ProcessControl {
 	public static ProcessBuilder newProcessBuilder(List<String> commandLine, boolean redirectErrorStream) {
 		return newProcessBuilder(commandLine,new HashMap<String,String>(), redirectErrorStream);
 	}
-	
+
 	public static ProcessBuilder newProcessBuilder(List<String> commandLine, Map<String,String> environment, boolean redirectErrorStream) {
 		ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
 		if (!environment.isEmpty()){

--- a/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
@@ -245,8 +245,8 @@ public class ProcessControl {
 	public static void addShutdownHook(Runnable runable) {
 		Runtime.getRuntime().addShutdownHook(new Thread(runable));
 	}
-	
-	public Integer getPid() {
+
+	public Long getPid() {
 		return pid;
 	}
 }

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
@@ -83,10 +83,10 @@ public abstract class Processes {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * @see http://www.golesny.de/p/code/javagetpid
-	 * 
+	 *
 	 * @return
 	 */
 	static Integer windowsProcessId(Process process) {
@@ -161,11 +161,11 @@ public abstract class Processes {
 				logger.trace("logWatch output: {}", logWatch.getOutput());
 				return logWatch.isInitWithSuccess();
 			}
-	
+
 		} catch (IOException e) {
 			logger.error("Trying to get process status", e);
 			e.printStackTrace();
-	
+
 		} catch (InterruptedException e) {
 			logger.error("Trying to get process status", e);
 			e.printStackTrace();

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
@@ -26,8 +26,12 @@ package de.flapdoodle.embed.process.runtime;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+
+import javax.lang.model.SourceVersion;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,19 +52,27 @@ public abstract class Processes {
 
 	private static Logger logger = LoggerFactory.getLogger(ProcessControl.class);
 
+	private static final PidHelper PID_HELPER;
+
+	static {
+		// Comparing with the string value to avoid a strong dependency on JDK 9
+		if (SourceVersion.latest().toString().equals( "RELEASE_9" )) {
+			PID_HELPER = PidHelper.JDK_9;
+		}
+		else {
+			PID_HELPER = PidHelper.LEGACY;
+		}
+	}
+
 	private Processes() {
 		// no instance
 	}
-	
-	public static Integer processId(Process process) {
-		Integer pid=unixLikeProcessId(process);
-		if (pid==null) {
-			pid=windowsProcessId(process);
-		}
-		return pid;
+
+	public static Long processId(Process process) {
+		return PID_HELPER.getPid(process);
 	}
 
-	static Integer unixLikeProcessId(Process process) {
+	private static Long unixLikeProcessId(Process process) {
 		Class<?> clazz = process.getClass();
 		try {
 			if (clazz.getName().equals("java.lang.UNIXProcess")) {
@@ -69,7 +81,7 @@ public abstract class Processes {
 				Object value = pidField.get(process);
 				if (value instanceof Integer) {
 					logger.debug("Detected pid: {}", value);
-					return (Integer) value;
+					return ((Integer) value).longValue();
 				}
 			}
 		} catch (SecurityException sx) {
@@ -89,7 +101,7 @@ public abstract class Processes {
 	 *
 	 * @return
 	 */
-	static Integer windowsProcessId(Process process) {
+	private static Long windowsProcessId(Process process) {
 		if (process.getClass().getName().equals("java.lang.Win32Process")
 				|| process.getClass().getName().equals("java.lang.ProcessImpl")) {
 			/* determine the pid on windows plattforms */
@@ -103,7 +115,7 @@ public abstract class Processes {
 				handle.setPointer(Pointer.createConstant(handl));
 				int ret = kernel.GetProcessId(handle);
 				logger.debug("Detected pid: {}", ret);
-				return ret;
+				return Long.valueOf(ret);
 			} catch (Throwable e) {
 				e.printStackTrace();
 			}
@@ -135,8 +147,8 @@ public abstract class Processes {
 		return false;
 	}
 
-	public static boolean isProcessRunning(Platform platform, int pid) {
-	
+	public static boolean isProcessRunning(Platform platform, long pid) {
+
 		try {
 			final Process pidof;
 			if (platform.isUnixLike()) {
@@ -171,5 +183,35 @@ public abstract class Processes {
 			e.printStackTrace();
 		}
 		return false;
+	}
+
+	private enum PidHelper {
+
+		JDK_9 {
+			@Override
+			Long getPid(Process process) {
+				try {
+					// Invoking via reflection to avoid a strong dependency on JDK 9
+					Method getPid = Process.class.getMethod("getPid");
+					return (Long) getPid.invoke(process);
+				}
+				catch (Exception e) {
+					e.printStackTrace();
+					return null;
+				}
+			}
+		},
+		LEGACY {
+			@Override
+			Long getPid(Process process) {
+				Long pid=unixLikeProcessId(process);
+				if (pid==null) {
+					pid=windowsProcessId(process);
+				}
+				return pid;
+			}
+		};
+
+		abstract Long getPid(Process process);
 	}
 }


### PR DESCRIPTION
By using the new `Process#getPid()` method, the PID retrieval also works on JDK 9 with this change. Note that I changed pid variables from int to long as that's what `getPid()` returns.

I've tested that fix successfully on OS X with JDK 8 and 9.