### PR TITLE
When getting the next entry from a Zip Archive, ensure that we have a ne...

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/extract/ZipExtractor.java
+++ b/src/main/java/de/flapdoodle/embed/process/extract/ZipExtractor.java
@@ -55,7 +55,7 @@ public class ZipExtractor extends AbstractExtractor {
 
         @Override
         public ArchiveEntry getNextEntry() throws IOException {
-            return entries.nextElement();
+            return entries.hasMoreElements() ? entries.nextElement() : null;
         }
 
         @Override


### PR DESCRIPTION
...xt element in a safer way as we can't reliably guarantee that Enumeration.nextElement() will return null at the end of the list.

In specific, when running on OS X Yosemite this actually used to cause a NPE to be thrown instead.