### PR TITLE
Adding embedded PostgreSQL link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Snapshots (Repository http://oss.sonatype.org/content/repositories/snapshots)
 - Embedded Redis [de.flapdoodle.de.embed.redis](https://github.com/flapdoodle-oss/de.flapdoodle.embed.redis)
 - Embedded Memcached [de.flapdoodle.embed.memcached](https://github.com/flapdoodle-oss/de.flapdoodle.embed.memcached)
 - Embedded node.js [nodejs.embed.flapdoodle.de](https://github.com/flapdoodle-oss/de.flapdoodle.embed.nodejs)
+- Embedded PostgreSQL [ru.yandex.qatools.embed](https://github.com/yandex-qatools/postgresql-embedded)
 
 ### Changelog
 


### PR DESCRIPTION
We've implemented the embedded PostgreSQL based on this library. It would be great to have a reference in this readme.