### PR TITLE
Allow a user to provide their own Distribution configuration

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/Starter.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Starter.java
@@ -46,9 +46,15 @@ public abstract class Starter<CONFIG extends IExecutableProcessConfig,EXECUTABLE
 	}
 
 	public EXECUTABLE prepare(CONFIG config) {
-		
-		Distribution distribution = Distribution.detectFor(config.version());
-		
+		return prepare(config, null);
+	}
+
+	public EXECUTABLE prepare(CONFIG config, Distribution distribution) {
+
+		if (distribution == null) {
+			distribution = Distribution.detectFor(config.version());
+		}
+
 		try {
 			IArtifactStore artifactStore = runtime.getArtifactStore();
 			


### PR DESCRIPTION
Allow a user to provide their own Distribution configuration instead of relying on detection only.