### PR TITLE
Fix: folders not precreated in extracted artifact store

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/extract/ExtractedFileSets.java
+++ b/src/main/java/de/flapdoodle/embed/process/extract/ExtractedFileSets.java
@@ -50,7 +50,8 @@ public abstract class ExtractedFileSets {
 		File oldExe = src.executable();
 		Builder builder = ImmutableExtractedFileSet.builder(destination)
 				.baseDirIsGenerated(directory.isGenerated());
-		
+
+		Files.createOrCheckDir(Files.fileOf(destination, oldExe).getParentFile());
 		Path newExeFile = java.nio.file.Files.copy(Files.fileOf(baseDir, oldExe).toPath(), Files.fileOf(destination, executableNaming.nameFor("extract", oldExe.getName())).toPath());
 		builder.executable(newExeFile.toFile());
 		

--- a/src/test/java/de/flapdoodle/embed/process/runtime/NetworkTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/NetworkTest.java
@@ -1,3 +1,26 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.flapdoodle.embed.process.runtime;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Only executable was forgotten, whereas other files are handled properly.