### PR TITLE
Don't add several shutdown hooks for process/executable combination

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/AbstractProcess.java
@@ -57,7 +57,8 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 	private long processId;
 
 	private boolean stopped = false;
-
+	private boolean registeredJobKiller;
+	
 	private final Distribution distribution;
 
 	private final File pidFile;
@@ -105,8 +106,9 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 
 			nextCall="addShutdownHook()";
 
-			if (runtimeConfig.isDaemonProcess()) {
+			if (runtimeConfig.isDaemonProcess() && !executable.isRegisteredJobKiller()) {
 				ProcessControl.addShutdownHook(new JobKiller());
+				registeredJobKiller = true;
 			}
 
 			nextCall="onAfterProcessStart()";
@@ -121,7 +123,12 @@ public abstract class AbstractProcess<T extends IExecutableProcessConfig, E exte
 		}
 	}
 
-	protected File pidFile(File executeableFile) {
+	@Override
+    public boolean isRegisteredJobKiller() {
+        return registeredJobKiller;
+    }
+
+    protected File pidFile(File executeableFile) {
 		return new File(executeableFile.getParentFile(),executableBaseName(executeableFile.getName())+".pid");
 	}
 

--- a/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Executable.java
@@ -42,7 +42,8 @@ public abstract class Executable<T extends IExecutableProcessConfig, P extends I
 	private final IRuntimeConfig runtimeConfig;
 	private final IExtractedFileSet executable;
 	private boolean stopped;
-
+	private boolean registeredJobKiller;
+	
 	List<IStopable> stopables = new ArrayList<IStopable>();
 
 	private final Distribution distribution;
@@ -56,10 +57,16 @@ public abstract class Executable<T extends IExecutableProcessConfig, P extends I
 		// clis being invoked will usually die by themselves
 		if (runtimeConfig.isDaemonProcess()) {
 			ProcessControl.addShutdownHook(new JobKiller());
+			registeredJobKiller = true;
 		}
 	}
+	
+	@Override
+    public boolean isRegisteredJobKiller() {
+        return registeredJobKiller;
+    }
 
-	/**
+    /**
 	 * use stop (this calls stop anyway)
 	 */
 	@Deprecated

--- a/src/main/java/de/flapdoodle/embed/process/runtime/IStopable.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/IStopable.java
@@ -26,4 +26,6 @@ package de.flapdoodle.embed.process.runtime;
 
 public interface IStopable {
 	void stop();
+	
+	boolean isRegisteredJobKiller();
 }


### PR DESCRIPTION
If a process is spawned from an executable that already has registered a shutdown hook, do not register another one for the process.

This is intended to be a basis for discussion:
1. Should `JobKiller` in `Executable` call a hook so that `Process` can provide additional steps for `stop()`?
2. Make the proposed behaviour optional and activated by some flag to not break current behaviour?

Solves duplicate shutdown attempts on windows for https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/172
