### PR TITLE
update commons-compress: 1.10 -> 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.12</version>
+			<version>1.14</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
In https://github.com/wix/wix-embedded-mysql I got bitten by https://issues.apache.org/jira/browse/COMPRESS-321 - namely extraction in windows fails due to misdetection of os/format.

Verified it fixed the issue.