### PR TITLE
[jdk9] java.lang.Process#getPid renamed to pid

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
@@ -192,7 +192,7 @@ public abstract class Processes {
 			Long getPid(Process process) {
 				try {
 					// Invoking via reflection to avoid a strong dependency on JDK 9
-					Method getPid = Process.class.getMethod("getPid");
+					Method getPid = Process.class.getMethod("pid");
 					return (Long) getPid.invoke(process);
 				}
 				catch (Exception e) {


### PR DESCRIPTION
I'm using this in a Java 9 project and works as expected.