### PR TITLE
Dependency + plugin updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
 	</profiles>
 
 	<properties>
-		<jna.version>4.2.2</jna.version>
+		<jna.version>4.5.1</jna.version>
 		<osgi.category>Bundles</osgi.category>
 		<osgi.export>
 			de.flapdoodle.embed.process;version=${project.version},
@@ -347,31 +347,31 @@
 		<dependency>
 			<groupId>de.flapdoodle.testdoc</groupId>
 			<artifactId>de.flapdoodle.testdoc</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.7.12</version>
+			<version>2.13.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>nl.jqno.equalsverifier</groupId>
 			<artifactId>equalsverifier</artifactId>
-			<version>2.1.7</version>
+			<version>2.4.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>value</artifactId>
-			<version>2.3.10</version>
+			<version>2.5.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>builder</artifactId>
-			<version>2.3.10</version>
+			<version>2.5.6</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -379,19 +379,19 @@
 			<!-- <groupId>org.apache.commons</groupId> - deprecated? -->
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
+			<version>2.6</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.7</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.14</version>
+			<version>1.15</version>
 		</dependency>
 
 		<dependency>
@@ -408,14 +408,14 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.24</version>
+			<version>1.7.25</version>
 		</dependency>
 
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.24</version>
+			<version>1.7.25</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -339,12 +339,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>de.flapdoodle.testdoc</groupId>
 			<artifactId>de.flapdoodle.testdoc</artifactId>
 			<version>1.2.1</version>
@@ -394,11 +388,6 @@
 			<version>1.15</version>
 		</dependency>
 
-		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna</artifactId>
-			<version>${jna.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna-platform</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.7.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -93,7 +93,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-6</version>
+						<version>1.0-beta-7</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -116,7 +116,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>2.20.1</version>
 				<configuration>
 					<excludes>
 						<exclude>**/live/**</exclude>
@@ -202,7 +202,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.5.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
@@ -219,7 +219,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.7.201606060606</version>
+				<version>0.8.0</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -247,7 +247,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -255,7 +255,7 @@
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<doclint>none</doclint>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Brings updates to Maven plugins and dependencies.

I would have updated the Checkstyle plugin, but it seems that the current config is broken:

```console
com.puppycrawl.tools.checkstyle.api.CheckstyleException: cannot initialize module TreeWalker - 
Unable to instantiate 'DoubleCheckedLocking' class, it is also not possible to instantiate it as (multiple more classes).
Please recheck that class name is specified as canonical name or read how to configure short name usage http://checkstyle.sourceforge.net/config.html#Packages. 
Please also recheck that provided ClassLoader to Checker is configured correctly.
```