### PR TITLE
Make pid method detection more resilient

### DIFF
--- a/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
@@ -1,0 +1,5 @@
+package de.flapdoodle.embed.process.runtime;
+
+public interface PidMethod {
+	long pid();
+}

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
@@ -1,0 +1,39 @@
+package de.flapdoodle.embed.process.runtime;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ProcessWithPidField extends Process {
+
+	private int pid = 123;
+
+	@Override
+	public OutputStream getOutputStream() {
+		return null;
+	}
+
+	@Override
+	public InputStream getInputStream() {
+		return null;
+	}
+
+	@Override
+	public InputStream getErrorStream() {
+		return null;
+	}
+
+	@Override
+	public int waitFor() throws InterruptedException {
+		return 0;
+	}
+
+	@Override
+	public int exitValue() {
+		return 0;
+	}
+
+	@Override
+	public void destroy() {
+
+	}
+}

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
@@ -1,0 +1,42 @@
+package de.flapdoodle.embed.process.runtime;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+
+import javax.lang.model.SourceVersion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.*;
+
+public class ProcessesTest {
+
+	@Test
+	public void usesPidMethodWithJava9() {
+		assumeTrue(SourceVersion.latest().toString().equals("RELEASE_9"));
+		Process mockProcess = mock(Process.class, withSettings().extraInterfaces(PidMethod.class));
+		when(((PidMethod) mockProcess).pid()).thenReturn(123L);
+		Long pid = Processes.processId(mockProcess);
+		verify((PidMethod) mockProcess).pid();
+		assertEquals(123L, pid.longValue());
+	}
+
+	@Test
+	public void usesPidMethodWithJava10() {
+		assumeTrue(SourceVersion.latest().toString().equals("RELEASE_10"));
+		Process mockProcess = mock(Process.class, withSettings().extraInterfaces(PidMethod.class));
+		when(((PidMethod) mockProcess).pid()).thenReturn(123L);
+		Long pid = Processes.processId(mockProcess);
+		verify((PidMethod) mockProcess).pid();
+		assertEquals(123L, pid.longValue());
+	}
+
+	@Test
+	public void usesPidFieldWithUNIXOSInJava8() {
+		assumeTrue(SourceVersion.latest().toString().equals("RELEASE_8") && SystemUtils.IS_OS_UNIX);
+		Process mockProcess = new ProcessWithPidField();
+		Long pid = Processes.processId(mockProcess);
+		assertEquals(123L, pid.longValue());
+	}
+}
+


### PR DESCRIPTION
Current method breaks every time when new JDK is released.
New method will decide based on if pid method exists on Process or not.