### PR TITLE
Fixed contributors in headers

### DIFF
--- a/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
@@ -4,7 +4,10 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	Maido Kaara (v3rm0n@github)
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/PidMethod.java
@@ -4,10 +4,7 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	konstantin-ba@github,
- Archimedes Trajano (trajano@github),
- Kevin D. Keck (kdkeck@github),
- Ben McCann (benmccann@github)
+ * 	Maido Kaara (v3rm0n@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
@@ -4,7 +4,10 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	Maido Kaara (v3rm0n@github)
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessWithPidField.java
@@ -4,10 +4,7 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	konstantin-ba@github,
- Archimedes Trajano (trajano@github),
- Kevin D. Keck (kdkeck@github),
- Ben McCann (benmccann@github)
+ * 	Maido Kaara (v3rm0n@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
@@ -4,7 +4,10 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	Maido Kaara (v3rm0n@github)
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/runtime/ProcessesTest.java
@@ -4,10 +4,7 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	konstantin-ba@github,
- Archimedes Trajano (trajano@github),
- Kevin D. Keck (kdkeck@github),
- Ben McCann (benmccann@github)
+ * 	Maido Kaara (v3rm0n@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Instead of copypasting, replaced contributors in the headers with actual contributors.

FYI circleci doesn't check for headers currently but build will fail if they are missing or broken...