### PR TITLE
Improvements for stopping a process

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/ProcessControl.java
@@ -4,10 +4,10 @@
  *   Martin Jöhren <m.joehren@googlemail.com>
  *
  * with contributions from
- * 	konstantin-ba@github,
-	Archimedes Trajano (trajano@github),
-	Kevin D. Keck (kdkeck@github),
-	Ben McCann (benmccann@github)
+ *   konstantin-ba@github,
+ *   Archimedes Trajano (trajano@github),
+ *   Kevin D. Keck (kdkeck@github),
+ *   Ben McCann (benmccann@github)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,24 +106,12 @@ public class ProcessControl {
 
 			boolean stopped=false;
 			try {
-				returnCode=task.get(100, TimeUnit.MILLISECONDS);
+				returnCode=task.get(15, TimeUnit.SECONDS);
 				stopped=true;
 			} catch (InterruptedException | ExecutionException | TimeoutException e) {
 			}
 
 			closeIOAndDestroy();
-
-			try {
-				returnCode=task.get(900, TimeUnit.MILLISECONDS);
-				stopped=true;
-			} catch (InterruptedException | ExecutionException | TimeoutException e) {
-			}
-
-			try {
-				returnCode=task.get(2000, TimeUnit.MILLISECONDS);
-				stopped=true;
-			} catch (InterruptedException | ExecutionException | TimeoutException e) {
-			}
 
 			if (!stopped)	{
 //				logger.severe(""+runtime.getName()+" NOT exited, thats why we destroy");


### PR DESCRIPTION
This cleans up the code a bit. I'm not sure why we currently try to stop the process three times. One seems sufficient.

Also, this increases the default timeout which is currently too low for mongodb. See https://github.com/flapdoodle-oss/de.flapdoodle.embed.process/issues/64