### PR TITLE
Refactor Files.moveFile to let flow the IOException

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/io/file/Files.java
+++ b/src/main/java/de/flapdoodle/embed/process/io/file/Files.java
@@ -198,19 +198,14 @@ public class Files {
 		java.nio.file.Files.write(output.toPath(), content.getBytes());
 	}
 
-	public static boolean moveFile(final File source, final File destination) {
-		try {
-			java.nio.file.Files.move(source.toPath(), destination.toPath());
-			return true;
-		} catch (IOException iox) {
-			return false;
-		}
+	public static void moveFile(final File source, final File destination) throws IOException {
+    java.nio.file.Files.move(source.toPath(), destination.toPath());
 	}
 
 	public static File fileOf(File base, File relative) {
 		return base.toPath().resolve(relative.toPath()).toFile();
 	}
-	
+
 	public static File fileOf(File base, String relative) {
 		return base.toPath().resolve(relative).toFile();
 	}

--- a/src/main/java/de/flapdoodle/embed/process/store/ExtractedArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/ExtractedArtifactStore.java
@@ -91,17 +91,18 @@ public class ExtractedArtifactStore implements IArtifactStore {
 				fileSetBuilder.addLibraryFiles(new File(FilesToExtract.fileName(file)));
 			}
 		}
-		
+
+		ExtractedFileSet extractedFileSet;
 		if (!foundExecutable) {
 			// we found no executable, so we trigger extraction and hope for the best
 			try {
-				baseStore.extractFileSet(distribution);
+				extractedFileSet = baseStore.extractFileSet(distribution);
 			} catch (FileAlreadyExistsException fx) {
 				throw new RuntimeException("extraction to "+destinationDir+" has failed", fx);
 			}
+		} else {
+			extractedFileSet = fileSetBuilder.build();
 		}
-		
-		ExtractedFileSet extractedFileSet = fileSetBuilder.build();
 		return ExtractedFileSets.copy(extractedFileSet, temp.getDirectory(), temp.getExecutableNaming());
 	}
 

--- a/src/main/java/de/flapdoodle/embed/process/store/LocalArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/LocalArtifactStore.java
@@ -25,6 +25,7 @@ package de.flapdoodle.embed.process.store;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 
 import de.flapdoodle.embed.process.config.store.DownloadConfig;
 import de.flapdoodle.embed.process.distribution.Distribution;
@@ -39,7 +40,6 @@ class LocalArtifactStore {
 		return getArtifact(runtime, distribution) != null;
 	}
 
-
 	public static boolean store(DownloadConfig runtime, Distribution distribution, File download) {
 		File dir = createOrGetBaseDir(runtime);
 		String artifactFileName = runtime.getPackageResolver().packageFor(distribution).archivePath();
@@ -47,8 +47,10 @@ class LocalArtifactStore {
 		createOrCheckDir(artifactFile.getParentFile());
 		try {
 			Files.moveFile(download, artifactFile);
-		} catch (IOException e) {
-			throw new IllegalArgumentException("Could not move " + download + " to " + artifactFile, e);
+		} catch (FileAlreadyExistsException faex) {
+			// Do nothing, supporting potential concurrence issues
+		} catch (IOException iox) {
+			throw new IllegalArgumentException("Could not move " + download + " to " + artifactFile, iox);
 		}
 		File checkFile = new File(dir, artifactFileName);
 		return checkFile.exists() && checkFile.isFile() && checkFile.canRead();

--- a/src/main/java/de/flapdoodle/embed/process/store/LocalArtifactStore.java
+++ b/src/main/java/de/flapdoodle/embed/process/store/LocalArtifactStore.java
@@ -24,6 +24,7 @@
 package de.flapdoodle.embed.process.store;
 
 import java.io.File;
+import java.io.IOException;
 
 import de.flapdoodle.embed.process.config.store.DownloadConfig;
 import de.flapdoodle.embed.process.distribution.Distribution;
@@ -44,10 +45,13 @@ class LocalArtifactStore {
 		String artifactFileName = runtime.getPackageResolver().packageFor(distribution).archivePath();
 		File artifactFile = new File(dir, artifactFileName);
 		createOrCheckDir(artifactFile.getParentFile());
-		if (!Files.moveFile(download, artifactFile))
-			throw new IllegalArgumentException("Could not move " + download + " to " + artifactFile);
+		try {
+			Files.moveFile(download, artifactFile);
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Could not move " + download + " to " + artifactFile, e);
+		}
 		File checkFile = new File(dir, artifactFileName);
-		return checkFile.exists() & checkFile.isFile() & checkFile.canRead();
+		return checkFile.exists() && checkFile.isFile() && checkFile.canRead();
 	}
 
 	private static File createOrGetBaseDir(DownloadConfig runtime) {

--- a/src/test/java/de/flapdoodle/embed/process/store/ExtractedArtifactStoreTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/store/ExtractedArtifactStoreTest.java
@@ -78,7 +78,7 @@ public class ExtractedArtifactStoreTest {
 			.tempDir(new TempDirInPlatformTempDir())
 			.downloader(failingDownloader())
 			.extractDir(extractedArtifactDir)
-			.extractExecutableNaming(new NoopTempNaming())
+			.extractExecutableNaming(new UUIDTempNaming())
 			.build();
 		
 		assertTrue("checkDistribution ("+distribution+")", store.checkDistribution(distribution));

--- a/src/test/java/de/flapdoodle/embed/process/store/LocalArtifactStoreTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/store/LocalArtifactStoreTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.store;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import de.flapdoodle.embed.process.TempDir;
+import de.flapdoodle.embed.process.config.store.DistributionPackage;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.config.store.DownloadConfigBuilder;
+import de.flapdoodle.embed.process.config.store.FileSet;
+import de.flapdoodle.embed.process.config.store.FileType;
+import de.flapdoodle.embed.process.config.store.PackageResolver;
+import de.flapdoodle.embed.process.distribution.ArchiveType;
+import de.flapdoodle.embed.process.distribution.Distribution;
+import de.flapdoodle.embed.process.distribution.Version;
+import de.flapdoodle.embed.process.extract.UUIDTempNaming;
+import de.flapdoodle.embed.process.io.directories.Directory;
+import de.flapdoodle.embed.process.io.progress.StandardConsoleProgressListener;
+
+public class LocalArtifactStoreTest {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void storingArtifactShouldNotFailWhenAlreadyExists() throws IOException {
+    Distribution distribution = Distribution.detectFor(Version.of("1.0.37"));
+
+    Directory artifactDir = new TempDir(tempFolder);
+
+    File source = new File(this.getClass().getResource("/mocks/mocked-artifact.zip").getPath());
+    Path copiedFile = Files.copy(source.toPath(),
+                                 artifactDir.asFile().toPath().resolve(artifactName(distribution)));
+    assertNotNull(copiedFile);
+
+    assertTrue(LocalArtifactStore.store(downloadConfig(artifactDir),
+                                        distribution,
+                                        source));
+  }
+
+  private static String artifactName(Distribution distribution) {
+    return ExtractedArtifactStore.asPath(distribution) + ".zip";
+  }
+
+  private DownloadConfig downloadConfig(Directory artifactDir) {
+    return new DownloadConfigBuilder().downloadPrefix("prefix")
+                                      .downloadPath("foo")
+                                      .packageResolver(packageResolver())
+                                      .artifactStorePath(artifactDir)
+                                      .fileNaming(new UUIDTempNaming())
+                                      .progressListener(new StandardConsoleProgressListener())
+                                      .userAgent("foo-bar")
+                                      .build();
+  }
+
+  private PackageResolver packageResolver() {
+    return new PackageResolver() {
+
+      @Override
+      public DistributionPackage packageFor(Distribution distribution) {
+        return DistributionPackage.of(getArchiveType(distribution),
+                                      getFileSet(distribution),
+                                      getPath(distribution));
+      }
+
+      public String getPath(Distribution distribution) {
+        return artifactName(distribution);
+      }
+
+      public FileSet getFileSet(Distribution distribution) {
+        return new FileSet.Builder().addEntry(FileType.Executable, "my-prog.bat")
+                                    .addEntry(FileType.Library, "lib/my-lib.txt", ".*my-lib.txt")
+                                    .build();
+      }
+
+      public ArchiveType getArchiveType(Distribution distribution) {
+        return ArchiveType.TGZ;
+      }
+    };
+  }
+}


### PR DESCRIPTION
The original implementation of wrapper class Files was hiding the original IOException preventing us to properly debug any IOException occurring at that level.

Fixes summary:
- Removed logic in Files.moveFile hiding IOExceptions
- Properly catch those IOException in LocalArtifactStore
- Improved LocalArtifactStore.store method to be resilient to concurrency issues in multi-threading process