### PR TITLE
Upgrade commons-compress dependency to version 1.18, because of security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.16.1</version>
+            <version>1.18</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade `commons-compress` dependency to version 1.18, because of security fixes:

> When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an infinite stream, which can be used to mount a denial of service attack against services that use Compress' zip package.