### PR TITLE
Configure doclint=none for maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -257,7 +257,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fix for https://github.com/flapdoodle-oss/de.flapdoodle.embed.process/issues/100