### PR TITLE
Add arm64(aarch64) support

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/distribution/Architecture.java
+++ b/src/main/java/de/flapdoodle/embed/process/distribution/Architecture.java
@@ -24,17 +24,28 @@
 package de.flapdoodle.embed.process.distribution;
 
 /**
- *
+ * Architecture enum
  */
-public enum BitSize {
-	B32,
-	B64;
+public enum Architecture {
+    I686,
+    AMD64,
+    AARCH64;
 
-	public static BitSize detect() {
-		BitSize bitSize = BitSize.B32;
-		String osArch = System.getProperty("os.arch");
-		if (osArch.endsWith("64"))
-			bitSize = BitSize.B64;
-		return bitSize;
-	}
+    public static Architecture detect() {
+        String architecture = System.getProperty("os.arch");
+        if (architecture.equalsIgnoreCase("i686")
+                || architecture.equalsIgnoreCase("i386")
+                || architecture.equalsIgnoreCase("x86")) {
+            return I686;
+        }
+        if (architecture.equalsIgnoreCase("i686_64")
+                || architecture.equalsIgnoreCase("x86_64")
+                || architecture.equalsIgnoreCase("amd64")) {
+            return AMD64;
+        }
+        if (architecture.equalsIgnoreCase("aarch64")) {
+            return AARCH64;
+        }
+        throw new IllegalArgumentException("Could not detect Architecture: os.arch=" + architecture);
+    }
 }

--- a/src/main/java/de/flapdoodle/embed/process/distribution/Distribution.java
+++ b/src/main/java/de/flapdoodle/embed/process/distribution/Distribution.java
@@ -31,11 +31,17 @@ public class Distribution {
 	private final IVersion version;
 	private final Platform platform;
 	private final BitSize bitsize;
+	private final Architecture architecture;
 
-	public Distribution(IVersion version, Platform platform, BitSize bitsize) {
+	public Distribution(IVersion version, Platform platform, BitSize bitsize, Architecture architecture) {
 		this.version = version;
 		this.platform = platform;
 		this.bitsize = bitsize;
+		this.architecture = architecture;
+	}
+
+	public Distribution(IVersion version, Platform platform, BitSize bitsize) {
+		this(version, platform, bitsize, Architecture.AMD64);
 	}
 
 	public IVersion getVersion() {
@@ -50,13 +56,17 @@ public class Distribution {
 		return bitsize;
 	}
 
+	public Architecture getArchitecture() {
+		return architecture;
+	}
+
 	@Override
 	public String toString() {
-		return "" + version + ":" + platform + ":" + bitsize;
+		return "" + version + ":" + platform + ":" + bitsize + ":" + architecture;
 	}
 
 	public static Distribution detectFor(IVersion version) {
-		return new Distribution(version, Platform.detect(), BitSize.detect());
+		return new Distribution(version, Platform.detect(), BitSize.detect(), Architecture.detect());
 	}
 
 	@Override
@@ -72,6 +82,9 @@ public class Distribution {
 		result = prime * result + ((version == null)
 				? 0
 				: version.hashCode());
+		result = prime * result + ((architecture == null)
+				? 0
+				: architecture.hashCode());
 		return result;
 	}
 
@@ -92,6 +105,8 @@ public class Distribution {
 			if (other.version != null)
 				return false;
 		} else if (!version.equals(other.version))
+			return false;
+		if (architecture != other.architecture)
 			return false;
 		return true;
 	}


### PR DESCRIPTION
While working on project running MongoDB both on amd64 and arm64(aarch64) machines I've found out that no arm64 support available. These changes are required by de.flapdoodle.embed.mongo project based on this project in order to provide arm64 support.