### PR TITLE
Add RELEASE_16 to Processes JDK detection to work with Java 16

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
+++ b/src/main/java/de/flapdoodle/embed/process/runtime/Processes.java
@@ -64,6 +64,7 @@ public abstract class Processes {
 		case "RELEASE_13":
 		case "RELEASE_14":
 		case "RELEASE_15":
+		case "RELEASE_16":
 			PID_HELPER = PidHelper.JDK_11;
 			break;
 		default:


### PR DESCRIPTION
When I was trying to use `de.flapdoodle.embed.mongo` together with Spring Boot 2.5 and Java 16 it failed with a

```
java.lang.NoSuchFieldException: handle
```

which I tracked down to

`de.flapdoodle.embed.process.runtime.Processes` where the static initliazer tries to detect the current Java version and applies different behaviour if it sees JDK [10->15].

I guess this needs to be extended with `RELEASE_16` to also cover Java 16.

*Important*

Even with this addition in place, simply adding the latest SNAPSHOT to my mentioned Spring Boot project does not work, because there seem to be breaking changes in `ProcessOutput` which make 

`org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration.RuntimeConfigConfiguration#embeddedMongoRuntimeConfig`

fail.

So this probably needs also be backported to some `de.flapdoodle.embed.process:3.0.x` release so that there is at least the option, to provide this an explicit dependency without breaking Spring Boots autoconfigurations.

Next step would then probably be to update `de.flapdoodle.embed.mongo` to depend on the updated `de.flapdoodle.embed.process` and last but not least, tell the Spring Boot folks to increase the version for `de.flapdoodle.embed.mongo` in their parent pom so that everything works flawlessly, again :)