### PR TITLE
feat: Don't copy extracted file if it already exists

### DIFF
--- a/src/main/java/de/flapdoodle/embed/process/extract/ExtractedFileSets.java
+++ b/src/main/java/de/flapdoodle/embed/process/extract/ExtractedFileSets.java
@@ -50,7 +50,13 @@ public abstract class ExtractedFileSets {
 				.baseDirIsGenerated(directory.isGenerated());
 
 		Files.createOrCheckDir(Files.fileOf(destination, oldExe).getParentFile());
-		Path newExeFile = java.nio.file.Files.copy(Files.fileOf(baseDir, oldExe).toPath(), Files.fileOf(destination, executableNaming.nameFor("extract", oldExe.getName())).toPath());
+		Path newExeFile = Files.fileOf(destination, executableNaming.nameFor("extract", oldExe.getName())).toPath();
+		if (!java.nio.file.Files.exists(newExeFile)) {
+			java.nio.file.Files.copy(Files.fileOf(baseDir, oldExe).toPath(), newExeFile);
+		}
+		else {
+			logger.info("Will not override {} because it already exists.", newExeFile);
+		}
 		builder.executable(newExeFile.toFile());
 
 		for (File srcFile : src.libraryFiles()) {

--- a/src/test/java/de/flapdoodle/embed/process/extract/ExtractedFileSetsTest.java
+++ b/src/test/java/de/flapdoodle/embed/process/extract/ExtractedFileSetsTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ * 	konstantin-ba@github,
+	Archimedes Trajano (trajano@github),
+	Kevin D. Keck (kdkeck@github),
+	Ben McCann (benmccann@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.process.extract;
+
+import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExtractedFileSetsTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void shouldNotCopyIfFileAlreadyExists() throws IOException {
+        // given
+        // Make sure we already have a file at the target destination
+        File platformTempDir = new File(System.getProperty("java.io.tmpdir"));
+        File executableInPlatformTempDir = new File(platformTempDir, "mongod");
+        Files.write(executableInPlatformTempDir.toPath(), "old".getBytes(StandardCharsets.UTF_8));
+
+        // when
+        File baseDir = temporaryFolder.newFolder();
+        File executable = new File(baseDir, "mongod");
+        Files.write(executable.toPath(), "new".getBytes(StandardCharsets.UTF_8));
+        ExtractedFileSet src = ExtractedFileSet.builder(baseDir).executable(executable).baseDirIsGenerated(false).build();
+
+        ExtractedFileSets.copy(src, new PlatformTempDir(), (prefix, postfix) -> "mongod");
+
+        // then
+        byte[] allBytes = Files.readAllBytes(executableInPlatformTempDir.toPath());
+        assertEquals("old", new String(allBytes, StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
We use your library in our open-source library [sda-dropwizard-commons](https://github.com/SDA-SE/sda-dropwizard-commons).

We have a small fix for developers on MacOS: For convenience we always use the same name of the MongoD executable to not get firewall notifications over and over again. Problem is that we sometimes get exceptions when the file already exists.

I changed the behaviour of the copy task. It will not do anything if the target file already exists. Of course, the behaviour could also be changed by always overwriting. What do you think? I didn't want to introduce another configuration option. 