### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
-                    <forkCount>0</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <excludes>
                         <exclude>**/live/**</exclude>
                         <exclude>**/examples/**</exclude>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
